### PR TITLE
fix network CLI argument being ignored

### DIFF
--- a/src/fresh.js
+++ b/src/fresh.js
@@ -10,18 +10,19 @@ const generateMetadata = require("./generate-metadata");
 const getConfig = require("./config");
 const { ECPrivateKey, signatureAlgorithms } = require("./flow/crypto");
 
-async function MakeFresh() {
-  const m = new Fresh();
+async function MakeFresh(network) {
+  const m = new Fresh(network);
   await m.init();
   return m;
 }
 
-async function MakeFlowMinter() {
-  return new FlowMinter();
+async function MakeFlowMinter(network) {
+  return new FlowMinter(network);
 }
 
 class Fresh {
-  constructor() {
+  constructor(network) {
+    this.network = network
     this.config = null;
     this.ipfs = null;
     this.nebulus = null;
@@ -36,7 +37,7 @@ class Fresh {
 
     this.config = getConfig();
 
-    this.flowMinter = await MakeFlowMinter();
+    this.flowMinter = await MakeFlowMinter(this.network);
 
     this.nebulus = new Nebulus({
       path: path.resolve(process.cwd(), this.config.nebulusPath)

--- a/src/fresh.js
+++ b/src/fresh.js
@@ -259,7 +259,7 @@ class Fresh {
    */
   async getNFT(tokenId) {
     const flowData = await this.flowMinter.getNFTDetails(
-      this.config.emulatorFlowAccount.address,
+      this.network === "testnet"? this.config.testnetFlowAccount.address : this.config.emulatorFlowAccount.address,
       tokenId
     );
 
@@ -346,7 +346,7 @@ class Fresh {
    * @returns {Promise<string>} - the default signing address that should own new tokens, if no owner was specified.
    */
   async defaultOwnerAddress() {
-    return this.config.emulatorFlowAccount.address;
+    return this.network === "testnet"? this.config.testnetFlowAccount.address : this.config.emulatorFlowAccount.address;
   }
 
   /** @returns {Promise<string>} - Amoutn of tokens funded */

--- a/src/fresh.js
+++ b/src/fresh.js
@@ -308,14 +308,18 @@ class Fresh {
   /**
    * Create a new NFT token that references the given metadata CID, owned by the given address.
    *
-   * @param {string} ownerAddress - the Flow address that should own the new token
    * @param {string} metadataURI - IPFS URI for the NFT metadata that should be associated with this token
    * @returns {Promise<any>} - The result from minting the token, includes events
    */
   async mintToken(metadataURI) {
     await this.flowMinter.setupAccount();
     const minted = await this.flowMinter.mint(metadataURI);
-    return formatMintResult(minted);
+
+    try {
+      return formatMintResult(minted);
+    } catch (error) {
+      console.log(minted);
+    }
   }
 
   async mintTokenWithClaimKey(metadataURI) {

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,11 @@ async function main() {
   program
     .command("inspect <token-id>")
     .description("get info from Flow about an NFT using its token ID")
+    .option(
+      "-n, --network <network>",
+      "Network to mint to. Either 'emulator', 'testnet' or 'mainnet'",
+      "emulator"
+    )
     .action(getNFT);
 
   program
@@ -91,12 +96,22 @@ async function main() {
   program
     .command("pin <token-id>")
     .description('"pin" the data for an NFT to a remote IPFS Pinning Service')
+    .option(
+      "-n, --network <network>",
+      "Network to mint to. Either 'emulator', 'testnet' or 'mainnet'",
+      "emulator"
+    )
     .action(pinNFTData);
 
   program
     .command("fund-account <address>")
     .description(
       "Transfer some tokens to an emulator account. Only works when using the emulator & dev-wallet."
+    )
+    .option(
+      "-n, --network <network>",
+      "Network to mint to. Either 'emulator', 'testnet' or 'mainnet'",
+      "emulator"
     )
     .action(fundAccount);
 
@@ -232,9 +247,9 @@ async function removeDrop(network) {
   spinner.succeed(`✨ Success! Drop removed. ✨`);
 }
 
-async function getNFT(tokenId) {
+async function getNFT(tokenId, network) {
   spinner.start(`Getting NFT data ...`);
-  const fresh = await MakeFresh("emulator");
+  const fresh = await MakeFresh(network);
   const nft = await fresh.getNFT(tokenId);
 
   const output = [
@@ -251,15 +266,15 @@ async function getNFT(tokenId) {
   spinner.succeed(`✨ Success! NFT data retrieved. ✨`);
 }
 
-async function pinNFTData(tokenId) {
-  const fresh = await MakeFresh("emulator");
+async function pinNFTData(tokenId, network) {
+  const fresh = await MakeFresh(network);
   await fresh.pinTokenData(tokenId);
   console.log(`🌿 Pinned all data for token id ${chalk.green(tokenId)}`);
 }
 
-async function fundAccount(address) {
+async function fundAccount(address, network) {
   spinner.start("Funding account  ...");
-  const fresh = await MakeFresh("emulator");
+  const fresh = await MakeFresh(network);
   const result = await fresh.fundAccount(address);
   spinner.succeed(
     `💰 ${result} FLOW tokens transferred to ${chalk.green(address)}`

--- a/src/index.js
+++ b/src/index.js
@@ -184,13 +184,13 @@ async function start() {
 
 async function deploy({ network }) {
   spinner.start(`Deploying project to ${network} ...`);
-  const fresh = await MakeFresh();
+  const fresh = await MakeFresh(network);
   await fresh.deployContracts();
   spinner.succeed(`✨ Success! Project deployed to ${network} ✨`);
 }
 
 async function batchMintNFT(options) {
-  const fresh = await MakeFresh();
+  const fresh = await MakeFresh(options.network);
 
   const answer = await inquirer.prompt({
     type: "confirm",
@@ -218,23 +218,23 @@ async function batchMintNFT(options) {
   spinner.succeed(`✨ Success! ${result.total} NFTs were minted! ✨`);
 }
 
-async function startDrop(price) {
+async function startDrop(price, network) {
   spinner.start(`Creating drop ...`);
-  const fresh = await MakeFresh();
+  const fresh = await MakeFresh(network);
   await fresh.startDrop(price);
   spinner.succeed(`✨ Success! Your drop is live. ✨`);
 }
 
-async function removeDrop() {
+async function removeDrop(network) {
   spinner.start(`Removing drop ...`);
-  const fresh = await MakeFresh();
+  const fresh = await MakeFresh(network);
   await fresh.removeDrop();
   spinner.succeed(`✨ Success! Drop removed. ✨`);
 }
 
 async function getNFT(tokenId) {
   spinner.start(`Getting NFT data ...`);
-  const fresh = await MakeFresh();
+  const fresh = await MakeFresh("emulator");
   const nft = await fresh.getNFT(tokenId);
 
   const output = [
@@ -252,14 +252,14 @@ async function getNFT(tokenId) {
 }
 
 async function pinNFTData(tokenId) {
-  const fresh = await MakeFresh();
+  const fresh = await MakeFresh("emulator");
   await fresh.pinTokenData(tokenId);
   console.log(`🌿 Pinned all data for token id ${chalk.green(tokenId)}`);
 }
 
 async function fundAccount(address) {
   spinner.start("Funding account  ...");
-  const fresh = await MakeFresh();
+  const fresh = await MakeFresh("emulator");
   const result = await fresh.fundAccount(address);
   spinner.succeed(
     `💰 ${result} FLOW tokens transferred to ${chalk.green(address)}`

--- a/src/index.js
+++ b/src/index.js
@@ -204,13 +204,14 @@ async function deploy({ network }) {
   spinner.succeed(`✨ Success! Project deployed to ${network} ✨`);
 }
 
-async function batchMintNFT(options) {
-  const fresh = await MakeFresh(options.network);
+async function batchMintNFT({data, network, claim}) {
+  // fresh.config.nftDataPath will not be equal to data, but this value is not used by Fresh.createNFTsFromCSVFile anyway
+  const fresh = await MakeFresh(network);
 
   const answer = await inquirer.prompt({
     type: "confirm",
     name: "confirm",
-    message: `Create NFTs using data from ${path.basename(options.data)}?`
+    message: `Create NFTs using data from ${path.basename(data)}?`
   });
 
   if (!answer.confirm) return;
@@ -218,8 +219,8 @@ async function batchMintNFT(options) {
   spinner.start("Minting your NFTs ...\n");
 
   const result = await fresh.createNFTsFromCSVFile(
-    options.data, 
-    options.claim, 
+    data, 
+    claim, 
     (nft) => {
       console.log(colorize(JSON.stringify(nft), colorizeOptions));
 

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -9,11 +9,12 @@ This project requires the Flow CLI and Docker.
 - [Install Flow CLI](https://docs.onflow.org/flow-cli/install/)
 - [Install Docker Desktop](https://www.docker.com/products/docker-desktop)
 
-Now install the project and its dependencies: 
+Now install the project and its dependencies:
 
 ```sh
 npm install
 ```
+
 ## Quick start
 
 This project uses the [Flow emulator](https://github.com/onflow/flow-emulator) for rapid local development.
@@ -23,6 +24,7 @@ This project uses the [Flow emulator](https://github.com/onflow/flow-emulator) f
 ```sh
 docker-compose up -d
 ```
+
 ### Deploy your contract to Flow
 
 (Ensure you run the following commands from your new project's directory)
@@ -35,11 +37,11 @@ fresh deploy
 
 This command mints the NFTs declared in `nfts.csv`. Edit that file to add your own NFTs!
 
-Notes: 
+Notes:
 
-- The metadata in the CSV is compatible with [OpenSea's NFT standard](https://docs.opensea.io/docs/metadata-standards). Freshmint does not enforce any standard metadata, but it is reccomended you consider using a standard format.
+- The metadata in the CSV is compatible with [OpenSea's NFT standard](https://docs.opensea.io/docs/metadata-standards). Freshmint does not enforce any standard metadata, but it is recommended you consider using a standard format.
 
-- Only the **image** property is required, and it's value must be the name of a file in the **assets/images** directory of your project. 
+- Only the **image** property is required, and it's value must be the name of a file in the **assets/images** directory of your project.
 
 ```sh
 fresh mint
@@ -48,7 +50,7 @@ fresh mint
 ### Mint a claimable NFT (i.e. airdrop support)
 
 Use the `claim` flag to create claim keys for your minted NFTs.
-Each NFT gets a unique claim key. 
+Each NFT gets a unique claim key.
 Give a key to a user to allow them to claim that NFT.
 
 ```sh
@@ -65,7 +67,7 @@ fresh inspect 0
 
 ### Pin the NFT metadata
 
-After you mint your NFTs, you'll need to pin the metdata to IPFS so that it's available to the world.
+After you mint your NFTs, you'll need to pin the metadata to IPFS so that it's available to the world.
 
 Hint: you can implement a blind drop by pinning the metadata _after_ your drop completes.
 
@@ -77,13 +79,13 @@ First configure your pinning service by editing `.env`:
 
 - **NFT.Storage**
 
-    [Create a free NFT.Storage account to get an API key](https://nft.storage/).
+  [Create a free NFT.Storage account to get an API key](https://nft.storage/).
 
-    ```sh
-    # .env
-    PINNING_SERVICE_ENDPOINT="https://nft.storage/api"
-    PINNING_SERVICE_KEY="Paste your nft.storage JWT token here!"
-    ```
+  ```sh
+  # .env
+  PINNING_SERVICE_ENDPOINT="https://nft.storage/api"
+  PINNING_SERVICE_KEY="Paste your nft.storage JWT token here!"
+  ```
 
 #### Pin an NFT
 

--- a/src/templates/cadence/scripts/queue/get_drop.cdc
+++ b/src/templates/cadence/scripts/queue/get_drop.cdc
@@ -1,5 +1,5 @@
-import {{ name }} from "../contracts/{{ name }}.cdc"
-import NFTQueueDrop from "../contracts/NFTQueueDrop.cdc"
+import {{ name }} from "../../contracts/{{ name }}.cdc"
+import NFTQueueDrop from "../../contracts/NFTQueueDrop.cdc"
 
 pub struct Drop {
 

--- a/src/templates/cadence/transactions/queue/remove_drop.cdc
+++ b/src/templates/cadence/transactions/queue/remove_drop.cdc
@@ -7,8 +7,6 @@ transaction {
 
         signer.unlink(NFTQueueDrop.DropPublicPath)
 
-        signer.load(<- drop, to: NFTQueueDrop.DropStoragePath)
-
         let drop <- signer.load<@NFTQueueDrop.Drop>(from: NFTQueueDrop.DropStoragePath)
 
         destroy drop

--- a/src/templates/web/src/fcl.config.js
+++ b/src/templates/web/src/fcl.config.js
@@ -2,11 +2,11 @@ import { config } from "@onflow/fcl";
 
 import getConfig from "next/config";
 
-const { publicRuntimeConfig: { appName } } = getConfig();
+const { publicRuntimeConfig } = getConfig();
 
 config()
   .put("env", "local")
   .put("app.detail.icon", "http://localhost:3000/favicon.png")
-  .put("app.detail.title", `${appName} NFT Drop`)
+  .put("app.detail.title", `${publicRuntimeConfig.appName} NFT Drop`)
   .put("accessNode.api", publicRuntimeConfig.flowAccessAPI)
   .put("discovery.wallet", publicRuntimeConfig.fclWalletDiscovery);


### PR DESCRIPTION
I was facing this error and I couldn't figure out why, so I read the code and I think I found a 🐛 bug.
The network CLI param is not used it seems.
```sh
→ fresh deploy --network 'testnet'
⠼ Deploying project to testnet ...Error: Command failed: flow project deploy         --network=emulator         -f flow.json         --update         -o json
❌ Command Error: failed to deploy all contracts
    at ChildProcess.exithandler (child_process.js:383:12)
    at ChildProcess.emit (events.js:400:28)
    at maybeClose (internal/child_process.js:1058:16)
    at Socket.<anonymous> (internal/child_process.js:443:11)
    at Socket.emit (events.js:400:28)
    at Pipe.<anonymous> (net.js:686:12) {
  killed: false,
  code: 1,
  signal: null,
  cmd: 'flow project deploy         --network=emulator         -f flow.json         --update         -o json',
  stdout: '\n',
  stderr: '❌ Command Error: failed to deploy all contracts'
}
```
specifically see the highlighting: the commander-js CLI argument is fine (the log says testnet) but the flow CLI command that is generated is using the wrong network.
![image](https://user-images.githubusercontent.com/7823843/144479367-03d280aa-cfd2-4be8-a574-7ce6d9097682.png)

Please guide me as to how I can test this PR 🙏 