### PR TITLE
Add dropAddress to claim transactions

### DIFF
--- a/src/templates/cadence/transactions/airdrop/claim_nft.cdc
+++ b/src/templates/cadence/transactions/airdrop/claim_nft.cdc
@@ -4,7 +4,7 @@ import FlowToken from "../../contracts/FlowToken.cdc"
 import FungibleToken from "../../contracts/FungibleToken.cdc"
 import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
 
-transaction(id: UInt64, signature: String) {
+transaction(dropAddress: Address, id: UInt64, signature: String) {
 
     let receiver: &{NonFungibleToken.CollectionPublic}
     let drop: &{NFTAirDrop.DropPublic}
@@ -28,7 +28,7 @@ transaction(id: UInt64, signature: String) {
             .getCapability({{ name }}.CollectionPublicPath)!
             .borrow<&{NonFungibleToken.CollectionPublic}>()!
 
-        self.drop = signer
+        self.drop = getAccount(dropAddress)
             .getCapability(NFTAirDrop.DropPublicPath)!
             .borrow<&{NFTAirDrop.DropPublic}>()!
     }

--- a/src/templates/cadence/transactions/queue/claim_nft.cdc
+++ b/src/templates/cadence/transactions/queue/claim_nft.cdc
@@ -4,7 +4,7 @@ import FlowToken from "../../contracts/FlowToken.cdc"
 import FungibleToken from "../../contracts/FungibleToken.cdc"
 import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
 
-transaction {
+transaction(dropAddress: Address) {
 
     let payment: @FungibleToken.Vault
     let receiver: &{NonFungibleToken.CollectionPublic}
@@ -26,7 +26,7 @@ transaction {
             .getCapability({{ name }}.CollectionPublicPath)!
             .borrow<&{NonFungibleToken.CollectionPublic}>()!
 
-        self.drop = signer
+        self.drop = getAccount(dropAddress)
             .getCapability(NFTQueueDrop.DropPublicPath)!
             .borrow<&{NFTQueueDrop.DropPublic}>()!
 

--- a/src/templates/web/src/components/AirDrop/index.js
+++ b/src/templates/web/src/components/AirDrop/index.js
@@ -6,7 +6,7 @@ import claimNft from "../../flow/airdrop/claim_nft";
 
 import AirDropButton from "./AirDropButton";
 
-export default function AirDrop({ nftId, privateKey }) {
+export default function AirDrop({ dropAddress, nftId, privateKey }) {
   const router = useRouter();
 
   const user = useCurrentUser();
@@ -19,7 +19,7 @@ export default function AirDrop({ nftId, privateKey }) {
     let txId;
 
     try {
-      txId = await claimNft(user.addr, nftId, privateKey);
+      txId = await claimNft(dropAddress, user.addr, nftId, privateKey);
     } catch (err) {
       setStatus({ isLoading: false, error: err });
       return;
@@ -31,7 +31,7 @@ export default function AirDrop({ nftId, privateKey }) {
         return;
       }
 
-      if (fcl.tx.isSealed(tx)) {        
+      if (fcl.tx.isSealed(tx)) {
         const event = tx.events.find((e) =>
           e.type.includes("NFTAirDrop.Claimed")
         );

--- a/src/templates/web/src/components/QueueDrop/index.js
+++ b/src/templates/web/src/components/QueueDrop/index.js
@@ -18,7 +18,7 @@ export default function QueueDrop({ dropAddress }) {
     let txId;
 
     try {
-      txId = await claimNft();
+      txId = await claimNft(dropAddress);
     } catch(err) {
       setStatus({ isLoading: false, error: err });
       return

--- a/src/templates/web/src/flow/airdrop/claim_nft.js
+++ b/src/templates/web/src/flow/airdrop/claim_nft.js
@@ -38,13 +38,14 @@ function generateNFTClaim(address, nftId, privateKeyHex) {
   return signature.toHex()
 }
 
-const claimNft = async (address, nftId, privateKey) => {
-  const signature = generateNFTClaim(address, nftId, privateKey)
+const claimNft = async (dropAddress, userAddress, nftId, privateKey) => {
+  const signature = generateNFTClaim(userAddress, nftId, privateKey)
 
   return await fcl.mutate({
     cadence: replaceImports(claim_nft),
     limit: 500,
     args: (arg, t) => [
+      arg(dropAddress, t.Address),
       arg(Number(nftId), t.UInt64),
       arg(signature, t.String)
     ]

--- a/src/templates/web/src/flow/queue/claim_nft.js
+++ b/src/templates/web/src/flow/queue/claim_nft.js
@@ -3,10 +3,13 @@ import * as fcl from "@onflow/fcl";
 import claim_nft from "../../../cadence/transactions/queue/claim_nft.cdc";
 import replaceImports from "../replace-imports";
 
-const claimNft = async () => {
+const claimNft = async (dropAddress) => {
   return await fcl.mutate({
     cadence: replaceImports(claim_nft),
-    limit: 500
+    limit: 500,
+    args: (arg, t) => [
+      arg(dropAddress, t.Address),
+    ]
   });
 };
 

--- a/src/templates/web/src/flow/queue/get_drop.js
+++ b/src/templates/web/src/flow/queue/get_drop.js
@@ -3,11 +3,11 @@ import * as fcl from "@onflow/fcl";
 import get_drop from "../../../cadence/scripts/queue/get_drop.cdc";
 import replaceImports from "../replace-imports";
 
-const getDrop = async (address) => {
+const getDrop = async (dropAddress) => {
   return await fcl.query({
     cadence: replaceImports(get_drop),
     args: (arg, t) => [
-      arg(address, t.Address),
+      arg(dropAddress, t.Address),
     ]
   });
 };


### PR DESCRIPTION
This PR fixes an error that @louisguitton reported in #11.

> cadence runtime error Execution failed:
> error: unexpectedly found nil while forcing an Optional value
> 31 |             .borrow<&{NFTQueueDrop.DropPublic}>()!

This was happening when running `queue/claim_nft.cdc` and `airdrop/claim_nft.cdc`. The previous versions of these transactions erroneously expected the signer to hold the drop object, which only works when the drop admin is buying from itself.