### PR TITLE
Upgrade to Next.js v12.1.5

### DIFF
--- a/src/templates/web/package.json
+++ b/src/templates/web/package.json
@@ -16,7 +16,7 @@
     "cids": "^1.1.9",
     "elliptic": "^6.5.4",
     "ipfs-only-hash": "^4.0.0",
-    "next": "^12.0.1",
+    "next": "^12.1.5",
     "next-seo": "^4.28.1",
     "nft.storage": "^3.3.0",
     "react": "17.0.2",


### PR DESCRIPTION
Upgrade to the latest version of Next.js in order fix imcompatiblity with Node 17 (#26), an issue that was also reported here: https://github.com/vercel/next.js/issues/30078

The problem was fixed in Next.js `12.0.3`.

Closes #26 